### PR TITLE
mysql, pg, sqlite3 moved under development_dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
   - TRAVIS_POSTGRESQL_VERSION=9.2
   - TRAVIS_POSTGRESQL_VERSION=9.1
 before_install:
-  - mysql -uroot -e "create database topaz"
+  - mysql -uroot -e "create database topaz_test"
   - sudo apt-get autoremove sqlite3
   - sudo apt-get install python-software-properties
   - sudo apt-add-repository -y ppa:travis-ci/sqlite3
@@ -20,6 +20,6 @@ before_install:
   - sudo service postgresql stop
   - sudo service postgresql start $TRAVIS_POSTGRESQL_VERSION
   - createuser root
-  - createdb topaz
-  - export DATABASE_URL=postgres://root@localhost/topaz
+  - createdb topaz_test
+  - export DATABASE_URL=postgres://root@localhost/topaz_test
 script: make

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ dependencies:
     github: topaz-crystal/topaz
 ```
 
+And install necessary drivers [SQLite3](https://github.com/crystal-lang/crystal-sqlite3),
+ [MySQL](https://github.com/crystal-lang/crystal-mysql), [PostgreSQL](https://github.com/will/crystal-pg).
+
 ## Usage
 
 **1. Setup DB**
@@ -97,6 +100,23 @@ See [sample code](https://github.com/topaz-crystal/topaz/blob/master/samples/ass
 
 **Supported data types.**  
 String, Int32, Int64, Float32, Float64  
+
+## Development
+
+Setting up PostgreSQL:
+
+```
+$ psql
+  # CREATE USER root WITH CREATEDB;
+  # CREATE DATABASE topaz_test WITH OWNER = root;
+```
+
+Setting up MySQL:
+
+```
+$ mysql -u root
+mysql> create database topaz_test;
+```
 
 ## Contributing
 

--- a/samples/association.cr
+++ b/samples/association.cr
@@ -1,4 +1,5 @@
 require "../src/topaz"
+require "sqlite3"
 
 ######################
 # Association Sample #

--- a/samples/json.cr
+++ b/samples/json.cr
@@ -1,4 +1,5 @@
 require "../src/topaz"
+require "sqlite3"
 
 ###############
 # Json Sample #

--- a/samples/model.cr
+++ b/samples/model.cr
@@ -1,4 +1,5 @@
 require "../src/topaz"
+require "sqlite3"
 
 ################
 # Model Sample #

--- a/samples/nullable.cr
+++ b/samples/nullable.cr
@@ -1,4 +1,5 @@
 require "../src/topaz"
+require "sqlite3"
 
 ###################
 # Nullable Column #

--- a/samples/time.cr
+++ b/samples/time.cr
@@ -1,4 +1,5 @@
 require "../src/topaz"
+require "sqlite3"
 
 #############################
 # created_at and updated_at #

--- a/samples/transaction.cr
+++ b/samples/transaction.cr
@@ -1,4 +1,5 @@
 require "../src/topaz"
+require "sqlite3"
 
 ######################
 # Transaction Sample #

--- a/shard.yml
+++ b/shard.yml
@@ -7,11 +7,17 @@ authors:
 license: MIT
 
 dependencies:
-  mysql:
-    github: crystal-lang/crystal-mysql
-  sqlite3:
-    github: crystal-lang/crystal-sqlite3
-  pg:
-    github: will/crystal-pg
   singleton:
     github: topaz-crystal/crystal-singleton
+  db:
+    github: crystal-lang/crystal-db
+
+development_dependencies:
+  mysql:
+    github: crystal-lang/crystal-mysql
+    branch: master
+  sqlite3:
+    github: crystal-lang/crystal-sqlite3
+    branch: master
+  pg:
+    github: will/crystal-pg

--- a/spec/db_spec.cr
+++ b/spec/db_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+require "sqlite3"
 
 describe Topaz do
   it "Setup db without any errors" do

--- a/spec/model/migration/mysql_before.cr
+++ b/spec/model/migration/mysql_before.cr
@@ -1,2 +1,3 @@
 require "./spec_for_migrations.cr"
-before_migration("mysql://root@localhost/topaz")
+require "mysql"
+before_migration("mysql://root@localhost/topaz_test")

--- a/spec/model/migration/mysql_exec.cr
+++ b/spec/model/migration/mysql_exec.cr
@@ -1,2 +1,3 @@
 require "./spec_for_migrations.cr"
-exec_migration("mysql://root@localhost/topaz")
+require "mysql"
+exec_migration("mysql://root@localhost/topaz_test")

--- a/spec/model/migration/pg_before.cr
+++ b/spec/model/migration/pg_before.cr
@@ -1,2 +1,3 @@
 require "./spec_for_migrations.cr"
-before_migration("postgres://root@localhost/topaz")
+require "pg"
+before_migration("postgres://root@localhost/topaz_test")

--- a/spec/model/migration/pg_exec.cr
+++ b/spec/model/migration/pg_exec.cr
@@ -1,2 +1,3 @@
 require "./spec_for_migrations.cr"
-exec_migration("postgres://root@localhost/topaz")
+require "pg"
+exec_migration("postgres://root@localhost/topaz_test")

--- a/spec/model/migration/sqlite3_before.cr
+++ b/spec/model/migration/sqlite3_before.cr
@@ -1,2 +1,3 @@
 require "./spec_for_migrations.cr"
+require "sqlite3"
 before_migration("sqlite3://./db/sample.db")

--- a/spec/model/migration/sqlite3_exec.cr
+++ b/spec/model/migration/sqlite3_exec.cr
@@ -1,2 +1,3 @@
 require "./spec_for_migrations.cr"
+require "sqlite3"
 exec_migration("sqlite3://./db/sample.db")

--- a/spec/model/mysql.cr
+++ b/spec/model/mysql.cr
@@ -1,2 +1,3 @@
+require "mysql"
 require "./specs_for_models"
-select_db("mysql://root@localhost/topaz")
+select_db("mysql://root@localhost/topaz_test")

--- a/spec/model/pg.cr
+++ b/spec/model/pg.cr
@@ -1,2 +1,3 @@
+require "pg"
 require "./specs_for_models"
-select_db("postgres://root@localhost/topaz")
+select_db("postgres://root@localhost/topaz_test")

--- a/spec/model/sqlite3.cr
+++ b/spec/model/sqlite3.cr
@@ -1,2 +1,3 @@
+require "sqlite3"
 require "./specs_for_models"
 select_db("sqlite3://./db/sample.db")

--- a/src/topaz/db.cr
+++ b/src/topaz/db.cr
@@ -1,7 +1,5 @@
 require "singleton"
-require "mysql"
-require "sqlite3"
-require "pg"
+require "db"
 
 module Topaz
   class Db

--- a/tools/install.rb
+++ b/tools/install.rb
@@ -195,6 +195,16 @@ def shard_yml_update
   shard_yml["dependencies"]["kemal"]["github"] = "kemalcr/kemal"
   shard_yml["dependencies"]["topaz"] = {}
   shard_yml["dependencies"]["topaz"]["github"] = "topaz-crystal/topaz"
+  if database.start_with?("sqlite3")
+    shard_yml["dependencies"]["sqlite3"] = {}
+    shard_yml["dependencies"]["sqlite3"]["github"] = "crystal-lang/crystal-sqlite3"
+  elsif database.start_with?("mysql")
+    shard_yml["dependencies"]["mysql"] = {}
+    shard_yml["dependencies"]["mysql"]["github"] = "crystal-lang/crystal-mysql"
+  elsif database.start_with?("postgres")
+    shard_yml["dependencies"]["pg"] = {}
+    shard_yml["dependencies"]["pg"]["github"] = "will/crystal-pg"
+  end
 
   File.delete "shard.yml"
   YAML.dump shard_yml, File.open("shard.yml", "w")
@@ -216,17 +226,17 @@ database     = input "Which database do you use?",
                      "sqlite3://./db/default.db"
 
 Dir.chdir install_dir do
-  
+
   exec_cmd "crystal init app #{project_name}"
-  
+
   Dir.chdir project_name do
-    
+
     log "Constructing project..."
-    
+
     shard_yml_update
 
     FileUtils.rm "src/#{project_name}.cr"
-    
+
     Dir.mkdir "bin"
     Dir.mkdir "db"
     Dir.mkdir "src/models"


### PR DESCRIPTION
Topaz now doesn't depend on all drivers. Users can install only necessary drivers. `README.md` and `tools/setup.rb` updated accordingly.
